### PR TITLE
Hide api key

### DIFF
--- a/source/scripts/apiHelpers.js
+++ b/source/scripts/apiHelpers.js
@@ -1,7 +1,9 @@
 // helper functions for Spoonacular API
 
 import { getAllRecipes } from './storage/fetcher.js';
-// require('dotenv').config();// REQUIRE DOES NOT WORK ON BROWSER HOW TO FIX?
+// eslint doesnt like the next line because API_KEY is currently not yet
+// in constants.js and will get populated once deployed on netlify
+// eslint-disable-next-line import/named
 import { API_KEY, HOST, DEV_MODE } from './constants.js';
 import TEST_DATA from './storage/sampleData.js';
 

--- a/source/scripts/constants.js
+++ b/source/scripts/constants.js
@@ -1,3 +1,2 @@
-export const API_KEY = 'c7d77a9cf1mshdef82375a448b1dp1a6592jsnaf7cb5469c24';// prevent exposing api key
 export const HOST = 'spoonacular-recipe-food-nutrition-v1.p.rapidapi.com';
 export const DEV_MODE = false;


### PR DESCRIPTION
## Details 
Remove exposed API key from Github Source code. This method will hide the key on Github but once it is deployed on Netlify, you can see the key if you inspect the source. IDK if this is a good solution because you can still see the key after deploying to Netlify but it's gone from GitHub. I couldn't figure out how to access the netlify environment variable directly.

 IMPORTANT: Faris can you add the following command to the build command in Netlify.
`echo "export const API_KEY = '${API_KEY}'" >> constants.js`
It should populate constants.js with the API_KEY so the functions can use it.

And make sure the env variable API_KEY is set in Netlify.

## New Changes
- removed API_KEY from constants.js

## Linked Issue
Closes #209 

## Screenshots
Please include screenshots of any visual changes to the project (new HTML/CSS)

## Checklist
 If it doesn't apply, just mark as completed
- [x] I have requested 2+ code reviewers
- [x] I have reviewed and commented my own code.
- [x] My code follows the style guidelines of this project.
- [x] I have added new tests as necessary.
- [x] All new and existing tests pass successfully.
