### PR TITLE
Removed unused Measurement Type button

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -359,7 +359,6 @@
                         </div>
                         <div class="measurements-wrapper">
                             <p class="info-subtitle">Measurements</p>
-                            <button class="info-page-btn unit-btn">Units: Imperial</button>
                             <div class="serving-adjust">
                                 <button class="info-page-btn measurement-btn" id="minus-btn">-</button>
                                 <div class="serving-size">4</div>


### PR DESCRIPTION
There was a button on the Expanded Recipe Info page that listed the type of measurement. Since we didn't implement measurement conversion, this button does nothing so we should remove it. 